### PR TITLE
add error messages such that %{value} works in custom error messages

### DIFF
--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -23,6 +23,11 @@ class EmailValidator < ActiveModel::EachValidator
     rescue Exception => e
       r = false
     end
-    record.errors.add attribute, (options[:message] || I18n.t(:invalid, :scope => "valid_email.validations.email")) unless r
+    if !r
+      # options is frozen, so make a copy
+      my_options = options.dup
+      my_options[:message] ||= I18n.t(:invalid, :scope => "valid_email.validations.email")
+      record.errors.add attribute, :invalid, my_options
+    end
   end
 end

--- a/lib/valid_email/mx_validator.rb
+++ b/lib/valid_email/mx_validator.rb
@@ -10,7 +10,12 @@ class MxValidator < ActiveModel::EachValidator
       mx.concat dns.getresources(m.domain, Resolv::DNS::Resource::IN::MX)
     end
     r = mx.size > 0
-    record.errors.add attribute, (options[:message] || I18n.t(:invalid, :scope => "valid_email.validations.email")) unless r
+    if !r
+      # For some reason I don't understand, options is
+      # frozen, but I can still modify it
+      options[:message] ||= I18n.t(:invalid, :scope => "valid_email.validations.email")
+      record.errors.add attribute, :invalid, options
+    end
     r
   end
 end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe EmailValidator do
-  person_class = Class.new do
+  class EmailValidatorClass
     include ActiveModel::Validations
     attr_accessor :email
     validates :email, :email => true
   end
 
-  person_class_mx = Class.new do
+  class MxRecordValidatorClass
     include ActiveModel::Validations
     attr_accessor :email
     validates :email, :email => {:mx => true}
@@ -21,7 +21,7 @@ describe EmailValidator do
     end
 
     describe "validating email" do
-      subject { person_class.new }
+      subject { EmailValidatorClass.new }
 
       it "should fail when email empty" do
         subject.valid?.should be_false
@@ -61,7 +61,7 @@ describe EmailValidator do
     end
 
     describe "validating email with MX" do
-      subject { person_class_mx.new }
+      subject { MxRecordValidatorClass.new }
 
       it "should pass when email domain has MX record" do
         subject.email = 'john@gmail.com'
@@ -95,5 +95,37 @@ describe EmailValidator do
     let!(:errors) { [ "est invalide" ] }
     it_should_behave_like "Validating emails"
   end
-  
+
+  describe "validating email with a custom message that contains the invalid value" do
+    class EmailValidatorClassWithCustomMessage
+      include ActiveModel::Validations
+      attr_accessor :email
+      validates :email, :email => {:message => "\"%{value}\" is not a valid email address"}
+    end
+
+    subject { EmailValidatorClassWithCustomMessage.new }
+
+    it "should fail and contain the invalid value in the error message" do
+      subject.email = 'joh@doe'
+      subject.valid?.should be_false
+      subject.errors[:email].should == ["\"#{subject.email}\" is not a valid email address"]
+    end
+  end
+
+  describe "validating mx record with a custom message that contains the invalid value" do
+    class MxRecordValidatorClassWithCustomMessage
+      include ActiveModel::Validations
+      attr_accessor :email
+      validates :email, :email => {:mx => true, :message => "\"%{value}\" does not have a valid MX record"}
+    end
+
+    subject { MxRecordValidatorClassWithCustomMessage.new }
+
+    it "should fail and contain the invalid value in the error message" do
+      subject.email = 'joh@doe'
+      subject.valid?.should be_false
+      subject.errors[:email].should == ["\"#{subject.email}\" does not have a valid MX record"]
+    end
+  end
+
 end


### PR DESCRIPTION
When I use upstream like this:

  validates :email, presence: true, email: { message: "\"%{value}\" is not a valid email address" }

the error message didn't have %{value} substituted with the actual invalid email address.  With this pull request, the actual invalid email address does appear.  There is some duplicate code between email_validator.rb and mx_validator.rb.  I'm not sure what the preferred way of handling that is.  I added some tests.  Along the way I needed to modify the way the test classes are created for reasons I don't totally understand.  Without the modification I ended up with errors like this:

     Failure/Error: subject.valid?.should be_false
     NameError:
       undefined local variable or method `all_options' for #<EmailValidator:0x007f8c5ce8e960>

So, there may be a cleaner way to do what I've done, but this should give you an idea of what I'm after.  Please consider including this in your repo.

Thanks.

-DB