### PR TITLE
Replace `be_true`/`be_false` with `be_truthy`/`be_falsey`

### DIFF
--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -66,49 +66,49 @@ describe EmailValidator do
       subject { person_class.new }
 
       it "should fail when email empty" do
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when email is not valid" do
         subject.email = 'joh@doe'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when email domain is prefixed with dot" do
         subject.email = 'john@.doe'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when email domain contains two consecutive dots" do
         subject.email = 'john@doe-two..com'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when email is valid with information" do
         subject.email = '"John Doe" <john@doe.com>'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should pass when email is simple email address" do
         subject.email = 'john@doe.com'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email is simple email address not stripped" do
         subject.email = 'john@doe.com            '
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when passing multiple simple email addresses" do
         subject.email = 'john@doe.com, maria@doe.com'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
@@ -119,19 +119,19 @@ describe EmailValidator do
 
       it "should pass when email domain has MX record" do
         subject.email = 'john@gmail.com'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should pass when email domain has no MX record but has an A record" do
         subject.email = 'john@subdomain.rubyonrails.org'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when domain does not exists" do
         subject.email = 'john@nonexistentdomain.abc'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
     end
@@ -141,19 +141,19 @@ describe EmailValidator do
 
       it "should pass when email domain has MX record" do
         subject.email = 'john@gmail.com'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email domain has no MX record" do
         subject.email = 'john@subdomain.rubyonrails.org'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when domain does not exists" do
         subject.email = 'john@nonexistentdomain.abc'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
     end
@@ -191,13 +191,13 @@ describe EmailValidator do
 
       it "should pass when email from trusted email services" do
         subject.email = 'john@mail.ru'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email from disposable email services" do
         subject.email = 'john@grr.la'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
     end

--- a/spec/extensions_validator_spec.rb
+++ b/spec/extensions_validator_spec.rb
@@ -6,17 +6,17 @@ describe String do
   it { "mymail@gmail".should respond_to(:email?) }
 
   it "is a valid e-mail" do
-    "mymail@gmail.com".email?.should be_true
+    "mymail@gmail.com".email?.should be_truthy
   end
 
   it "is not valid when text is not a real e-mail" do
-    "invalidMail".email?.should be_false
+    "invalidMail".email?.should be_falsey
   end
 
   context "when nil" do
 
     it "is invalid e-mail" do
-      nil.email?.should be_false
+      nil.email?.should be_falsey
     end
 
   end


### PR DESCRIPTION
Because `be_true` and `be_false` were deprecated in rspec v2.99, see
https://github.com/rspec/rspec-expectations/blob/master/Changelog.md#2990beta1--2013-11-07
