### PR TITLE
Remove .rvmrc file

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use --create ruby-1.9.3@email_validator


### PR DESCRIPTION
Remove .rvmrc file

This gem works with most ruby implementations and so it is inappropriate to specify that development is done in one specific ruby.
