### PR TITLE
Cache queries for each domain when Rails.cache is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ nil.email? # => false
 "john@gmail.com".email? # => May return true if it exists. It accepts a hash of options like ValidateEmail.valid?
 ```
 
+## Caching MX lookups in Rails
+
+Doing lots of MX/DNS lookups is slow and for performace reasons its preferable to cache queries for each domain.
+
+You can create an initializer in your Rails app and configure how long you'd like to cache lookups for. Caching is turned off by default.
+
+```ruby
+# config/initializers/valid_email.rb
+
+ValidateEmail.configure do |config|
+  config.cache_mx_lookups_for = 5.hours
+end
+```
+
 ## Code Status
 
 * [![Build Status](https://travis-ci.org/hallelujah/valid_email.svg?branch=master)](https://travis-ci.org/hallelujah/valid_email)

--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -1,5 +1,15 @@
 class ValidateEmail
   class << self
+    attr_accessor :configuration
+
+    def configure
+      yield(configuration)
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
     def valid?(value, user_options={})
       options = { :mx => false, :message => nil }.merge(user_options)
 
@@ -33,13 +43,16 @@ class ValidateEmail
       m = Mail::Address.new(value)
       return false unless m.domain
 
-      mx = []
-      Resolv::DNS.open do |dns|
-        mx.concat dns.getresources(m.domain, Resolv::DNS::Resource::IN::MX)
-        mx.concat dns.getresources(m.domain, Resolv::DNS::Resource::IN::A) if fallback
+      mx = if defined?(::Rails) && ValidateEmail.configuration.cache_mx_lookups_for.is_a?(Fixnum)
+        cache_key = ['valid_email/mx_valid?', m.domain, fallback]
+        Rails.cache.fetch(cache_key, expires_in: ValidateEmail.configuration.cache_mx_lookups_for) do
+          domain_mx_records(m.domain, fallback)
+        end
+      else
+        domain_mx_records(m.domain, fallback)
       end
 
-      return mx.any?
+      mx.any?
     rescue Mail::Field::ParseError
       false
     end
@@ -53,6 +66,25 @@ class ValidateEmail
       m.domain && !BanDisposableEmailValidator.config.include?(m.domain)
     rescue Mail::Field::ParseError
       false
+    end
+
+    def domain_mx_records(domain, fallback=false)
+      mx = []
+
+      Resolv::DNS.open do |dns|
+        mx.concat dns.getresources(domain, Resolv::DNS::Resource::IN::MX)
+        mx.concat dns.getresources(domain, Resolv::DNS::Resource::IN::A) if fallback
+      end
+
+      return mx
+    end
+  end
+
+  class Configuration
+    attr_accessor :cache_mx_lookups_for
+
+    def initialize
+      @cache_mx_lookups_for = nil
     end
   end
 end


### PR DESCRIPTION
Doing lots of MX/DNS lookups is slow and for performace reasons its preferable to cache queries for each domain.

This allows caching when ```Rails.cache``` is available and a caching duration is set for ValidEmail.