### PR TITLE
Do not allow double dots and dots in beginning or end of local part of address

### DIFF
--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -18,6 +18,9 @@ class ValidateEmail
       domain_dot_elements = m.domain.split(/\./)
       return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
 
+      # Two dots next to each other or a dot at the beginning or end of the local part are not allowed by RFC2822.
+      return false unless m.local.split('.', -1).all?(&:present?)
+
       # Check if domain has DNS MX record
       if options[:mx]
         require 'valid_email/mx_validator'

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -4,10 +4,14 @@ describe ValidateEmail do
   describe '.valid?' do
     it 'should return true when passed email has valid format' do
       ValidateEmail.valid?('user@gmail.com').should be_truthy
+      ValidateEmail.valid?('valid.user@gmail.com').should be_truthy
     end
 
     it 'should return false when passed email has invalid format' do
       ValidateEmail.valid?('user@gmail.com.').should be_falsey
+      ValidateEmail.valid?('user.@gmail.com').should be_falsey
+      ValidateEmail.valid?('.user@gmail.com').should be_falsey
+      ValidateEmail.valid?('us..er@gmail.com').should be_falsey
     end
 
     context 'when mx: true option passed' do


### PR DESCRIPTION
Many mail servers do not accept emails to addresses like <foo.bar.@gmail.com>, so we should treat them as invalid.

See http://www.remote.org/jochen/mail/info/chars.html for details.