### PR TITLE
Added local segment validation to email validator

### DIFF
--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -1,7 +1,7 @@
 class ValidateEmail
   class << self
-    SPECIAL_CHARS = ['(', ')', ',', ':', ';', '<', '>', '@', '[', ']']
-    SPECIAL_ESCAPED_CHARS = [' ', '\\', '"']
+    SPECIAL_CHARS = %w(( ) , : ; < > @ [ ])
+    SPECIAL_ESCAPED_CHARS = %w(\  \\ ")
     LOCAL_MAX_LEN = 64
 
     def valid?(value, user_options={})

--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -1,5 +1,9 @@
 class ValidateEmail
   class << self
+    SPECIAL_CHARS = ['(', ')', ',', ':', ';', '<', '>', '@', '[', ']']
+    SPECIAL_ESCAPED_CHARS = [' ', '\\', '"']
+    LOCAL_MAX_LEN = 64
+
     def valid?(value, user_options={})
       options = { :mx => false, :message => nil }.merge(user_options)
 
@@ -18,8 +22,8 @@ class ValidateEmail
       domain_dot_elements = m.domain.split(/\./)
       return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
 
-      # Two dots next to each other or a dot at the beginning or end of the local part are not allowed by RFC2822.
-      return false unless m.local.split('.', -1).all?(&:present?)
+      # Ensure that the local segment adheres to adheres to RFC-5322
+      return false unless valid_local?(m.local)
 
       # Check if domain has DNS MX record
       if options[:mx]
@@ -30,6 +34,38 @@ class ValidateEmail
       true
     rescue Mail::Field::ParseError
       false
+    end
+
+    def valid_local?(local)
+      return false unless local.length <= LOCAL_MAX_LEN
+      # Emails can be validated by segments delineated by '.', referred to as dot atoms.
+      # See http://tools.ietf.org/html/rfc5322#section-3.2.3
+      return local.split('.', -1).all? { |da| valid_dot_atom?(da) }
+    end
+
+    def valid_dot_atom?(dot_atom)
+      # Leading, trailing, and double '.'s aren't allowed
+      return false if dot_atom.empty?
+      # A dot atom can be quoted, which allows use of the SPECIAL_CHARS
+      if dot_atom[0] == '"' || dot_atom[-1] == '"'
+        # A quoted segment must have leading and trailing '"#"'s
+        return false if dot_atom[0] != dot_atom[-1]
+
+        # Excluding the bounding quotes, all of the SPECIAL_ESCAPED_CHARS must have a leading '\'
+        index = dot_atom.length - 2
+        while index > 0
+          if SPECIAL_ESCAPED_CHARS.include? dot_atom[index]
+            return false if index == 1 || dot_atom[index - 1] != '\\'
+            # On an escaped special character, skip an index to ignore the '\' that's doing the escaping
+            index -= 1
+          end
+          index -= 1
+        end
+      else
+        # If we're not in a quoted dot atom then no special characters are allowed.
+        return false unless ((SPECIAL_CHARS | SPECIAL_ESCAPED_CHARS) & dot_atom.split('')).empty?
+      end
+      return true 
     end
 
     def mx_valid?(value, fallback=false)

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -55,7 +55,7 @@ describe ValidateEmail do
       ValidateEmail.valid_local?('"\\\\"').should be_truthy
       ValidateEmail.valid_local?('test."te@st".test').should be_truthy
       ValidateEmail.valid_local?('test."\\\\\"".test').should be_truthy
-      ValidateEmail.valid_local?('test."blah\"\ \\"')
+      ValidateEmail.valid_local?('test."blah\"\ \\\\"').should be_truthy
     end
 
     it 'should return true if all characters are within the set of allowed characters' do

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -10,8 +10,6 @@ describe ValidateEmail do
     it 'should return false when passed email has invalid format' do
       ValidateEmail.valid?('user@gmail.com.').should be_falsey
       ValidateEmail.valid?('user.@gmail.com').should be_falsey
-      ValidateEmail.valid?('.user@gmail.com').should be_falsey
-      ValidateEmail.valid?('us..er@gmail.com').should be_falsey
     end
 
     context 'when mx: true option passed' do
@@ -22,6 +20,46 @@ describe ValidateEmail do
       it "should return false when mx record doesn't exist" do
         ValidateEmail.valid?('user@example.com', mx: true).should be_falsey
       end
+    end
+  end
+
+  describe '.valid_local?' do
+    it 'should return false if the local segment is too long' do
+      ValidateEmail.valid_local?(
+        'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde'
+      ).should be_falsey
+    end
+
+    it 'should return false if the local segment has an empty dot atom' do
+      ValidateEmail.valid_local?('.user').should be_falsey
+      ValidateEmail.valid_local?('.user.').should be_falsey
+      ValidateEmail.valid_local?('user.').should be_falsey
+      ValidateEmail.valid_local?('us..er').should be_falsey
+    end
+
+    it 'should return false if the local segment has a special character in an unquoted dot atom' do
+      ValidateEmail.valid_local?('us@er').should be_falsey
+      ValidateEmail.valid_local?('user.\\.name').should be_falsey
+      ValidateEmail.valid_local?('user."name').should be_falsey
+    end
+
+    it 'should return false if the local segment has an unescaped special character in a quoted dot atom' do
+      ValidateEmail.valid_local?('test." test".test').should be_falsey
+      ValidateEmail.valid_local?('test."test\".test').should be_falsey
+      ValidateEmail.valid_local?('test."te"st".test').should be_falsey
+      ValidateEmail.valid_local?('test."\".test').should be_falsey
+    end
+
+    it 'should return true if special characters exist but are properly quoted and escaped' do
+      ValidateEmail.valid_local?('"\ test"').should be_truthy
+      ValidateEmail.valid_local?('"\\\\"').should be_truthy
+      ValidateEmail.valid_local?('test."te@st".test').should be_truthy
+      ValidateEmail.valid_local?('test."\\\\\"".test').should be_truthy
+      ValidateEmail.valid_local?('test."blah\"\ \\"')
+    end
+
+    it 'should return true if all characters are within the set of allowed characters' do
+      ValidateEmail.valid_local?('!#$%&\'*+-/=?^_`{|}~."\\\\\ \"(),:;<>@[]"').should be_truthy
     end
   end
 end


### PR DESCRIPTION
Manually handling exceptions caused by invalid local segments of email addresses is always a hassle, o I figured it made sense to extend this library to cover the full gamut of requirements outlined in [RFC-5322](http://tools.ietf.org/html/rfc5322), specifically sections 3.2.3 and 3.2.4. I specifically eschewed using any regular expressions per this library's documentation.

For a more accessible guide to the rules I'm matching check out [this discussion](https://social.technet.microsoft.com/Forums/exchange/en-US/69f393aa-d555-4f8f-bb16-c636a129fc25/what-are-valid-and-invalid-email-address-characters).

Thanks for your consideration! Let me know if there's anything you think should be tweaked!

