### PR TITLE
fix uninitialized constant in lib/valid_email/validate_email.rb

### DIFF
--- a/lib/valid_email/ban_disposable_email_validator.rb
+++ b/lib/valid_email/ban_disposable_email_validator.rb
@@ -1,6 +1,5 @@
 require 'active_model'
 require 'active_model/validations'
-require 'mail'
 require 'valid_email/validate_email'
 class BanDisposableEmailValidator < ActiveModel::EachValidator
   # A list of disposable email domains

--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -1,6 +1,5 @@
 require 'active_model'
 require 'active_model/validations'
-require 'mail'
 require 'valid_email/validate_email'
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record,attribute,value)

--- a/lib/valid_email/mx_validator.rb
+++ b/lib/valid_email/mx_validator.rb
@@ -1,6 +1,5 @@
 require 'active_model'
 require 'active_model/validations'
-require 'mail'
 require 'resolv'
 require 'valid_email/validate_email'
 class MxValidator < ActiveModel::EachValidator

--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -1,3 +1,5 @@
+require 'mail'
+
 class ValidateEmail
   class << self
     SPECIAL_CHARS = %w(( ) , : ; < > @ [ ])


### PR DESCRIPTION
This file needed a ```require 'mail'``` to eliminate the exception.