### PR TITLE
Replace #present? usage to !#empty?

### DIFF
--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -20,7 +20,7 @@ class ValidateEmail
       return false unless m.domain.match(/^\S+$/)
 
       domain_dot_elements = m.domain.split(/\./)
-      return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
+      return false unless domain_dot_elements.size > 1 && !domain_dot_elements.any?(&:empty?)
 
       # Ensure that the local segment adheres to adheres to RFC-5322
       return false unless valid_local?(m.local)


### PR DESCRIPTION
This enables the use of `ValidateEmail` in pure Ruby projects that don't
patch `String#present?`

Fixes #64