### PR TITLE
Add license flag to the gemspec

### DIFF
--- a/valid_email.gemspec
+++ b/valid_email.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://my.rails-royce.org/2010/07/21/email-validation-in-ruby-on-rails-without-regexp"
   s.summary     = %q{ActiveModel Validation for email}
   s.description = %q{ActiveModel Validation for email}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "valid_email"
 


### PR DESCRIPTION
I picked the MIT license, as the LICENSE file looks like MIT.
I would like to add this because it will make automated license checking using [dblock/gem-license](https://github.com/dblock/gem-licenses) easier.