### PR TITLE
Fix message option

### DIFF
--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -10,19 +10,19 @@ class EmailValidator < ActiveModel::EachValidator
     # Check if domain has DNS MX record
     if r && options[:mx]
       require 'valid_email/mx_validator'
-      r = MxValidator.new(:attributes => attributes).validate(record)
+      r = MxValidator.new(:attributes => attributes, message: options[:message]).validate(record)
     elsif r && options[:mx_with_fallback]
       require 'valid_email/mx_with_fallback_validator'
-      r = MxWithFallbackValidator.new(:attributes => attributes).validate(record)
+      r = MxWithFallbackValidator.new(:attributes => attributes, message: options[:message]).validate(record)
     end
     # Check if domain is disposable
     if r && options[:ban_disposable_email]
       require 'valid_email/ban_disposable_email_validator'
-      r = BanDisposableEmailValidator.new(:attributes => attributes).validate(record)
+      r = BanDisposableEmailValidator.new(:attributes => attributes, message: options[:message]).validate(record)
     end
     unless r
       msg = (options[:message] || I18n.t(:invalid, :scope => "valid_email.validations.email"))
       record.errors.add attribute, (msg % {value: value})
-    end  
+    end
   end
 end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -55,6 +55,12 @@ describe EmailValidator do
     validates :email, :domain => true
   end
 
+  person_message_specified = Class.new do
+    include ActiveModel::Validations
+    attr_accessor :email
+    validates :email, :email => { :message => 'custom message', :ban_disposable_email => true }
+  end
+
   shared_examples_for "Invalid model" do
     before { subject.valid? }
 
@@ -239,7 +245,6 @@ describe EmailValidator do
       expect(subject).to be_valid
       expect(subject.errors[:email]).to be_empty
     end
-
   end
 
   describe "Can allow blank" do
@@ -250,7 +255,16 @@ describe EmailValidator do
       expect(subject).to be_valid
       expect(subject.errors[:email]).to be_empty
     end
+  end
 
+  describe "Accepts custom messages" do
+    subject { person_message_specified.new }
+
+    it "adds only the custom error" do
+      subject.email = 'bad@mailnator.com'
+      expect(subject.valid?).to be_falsey
+      expect(subject.errors[:email]).to match_array [ 'custom message' ]
+    end
   end
 
   describe "Translating in english" do
@@ -261,7 +275,6 @@ describe EmailValidator do
 
   describe "Translating in french" do
     let!(:locale){ :fr }
-
     let!(:errors) { [ "est invalide" ] }
     it_behaves_like "Validating emails"
   end


### PR DESCRIPTION
Supplying a message does not currently work if you also use one of the other options, such as mx, ban_disposable_email, etc, because message is not passed to the secondary validators.