### PR TITLE
add a configurable timeout for DNS resolution

### DIFF
--- a/config/valid_email.yml
+++ b/config/valid_email.yml
@@ -1,3 +1,4 @@
+resolv_dns_timeouts: 0.05
 disposable_email_services:
   - mailinator.com
   - devnullmail.com

--- a/lib/valid_email.rb
+++ b/lib/valid_email.rb
@@ -1,5 +1,23 @@
 require 'valid_email/all'
 I18n.load_path += Dir.glob(File.expand_path('../../config/locales/**/*',__FILE__))
+
+class ValidEmail 
+  def self.config= options
+    @@config = options
+  end
+
+  def self.disposable_email_services
+    @@config['disposable_email_services'] || []
+  end
+
+  def self.resolv_dns_timeouts
+    @@config['resolv_dns_timeouts'] || 0.5
+  end
+end
+
 # Load list of disposable email domains
-config = File.expand_path('../../config/valid_email.yml',__FILE__)
-BanDisposableEmailValidator.config= YAML.load_file(config)['disposable_email_services'] rescue []
+config_yaml = File.expand_path('../../config/valid_email.yml',__FILE__)
+ValidEmail.config = YAML.load_file(config_yaml)
+
+BanDisposableEmailValidator.config= ValidEmail.disposable_email_services
+

--- a/lib/valid_email.rb
+++ b/lib/valid_email.rb
@@ -1,7 +1,7 @@
 require 'valid_email/all'
 I18n.load_path += Dir.glob(File.expand_path('../../config/locales/**/*',__FILE__))
 
-class ValidEmail 
+class ValidEmail
   def self.config= options
     @@config = options
   end
@@ -10,8 +10,20 @@ class ValidEmail
     @@config['disposable_email_services'] || []
   end
 
-  def self.resolv_dns_timeouts
-    @@config['resolv_dns_timeouts'] || 0.5
+  def self.dns_timeout= value
+    @@config['dns_timeout'] = value
+  end
+
+  def self.dns_timeout
+    @@config['dns_timeout'] || 0.5
+  end
+
+  def self.dns_timeout_return_value= value
+    @@config['dns_timeout_return_value'] = value
+  end
+
+  def self.dns_timeout_return_value
+    @@config['dns_timeout_return_value'] || true
   end
 end
 
@@ -20,4 +32,3 @@ config_yaml = File.expand_path('../../config/valid_email.yml',__FILE__)
 ValidEmail.config = YAML.load_file(config_yaml)
 
 BanDisposableEmailValidator.config= ValidEmail.disposable_email_services
-

--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -92,6 +92,7 @@ class ValidateEmail
 
       mx = []
       Resolv::DNS.open do |dns|
+        dns.timeouts = ValidEmail.resolv_dns_timeouts
         mx.concat dns.getresources(m.domain, Resolv::DNS::Resource::IN::MX)
         mx.concat dns.getresources(m.domain, Resolv::DNS::Resource::IN::A) if fallback
       end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -70,8 +70,11 @@ describe EmailValidator do
 
   shared_examples_for "Validating emails" do
 
+    let(:timeouts) { 1 }
+
     before :each do
       I18n.locale = locale
+      allow(ValidEmail).to receive(:resolv_dns_timeouts).and_return timeouts
     end
 
     describe "validating email" do
@@ -166,6 +169,7 @@ describe EmailValidator do
       it "fails when email domain has no MX record" do
         subject.email = 'john@subdomain.rubyonrails.org'
         expect(subject.valid?).to be_falsey
+
         expect(subject.errors[:email]).to eq errors
       end
 
@@ -173,6 +177,14 @@ describe EmailValidator do
         subject.email = 'john@nonexistentdomain.abc'
         expect(subject.valid?).to be_falsey
         expect(subject.errors[:email]).to eq errors
+      end
+
+      describe "Resolv::DNS.timeouts" do
+        it "sets the timeouts on the DNS" do
+          expect_any_instance_of(Resolv::DNS).to receive(:timeouts=).with(timeouts)
+          subject.email = 'john@gmail.com'
+          subject.valid?
+        end
       end
     end
 

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -70,11 +70,8 @@ describe EmailValidator do
 
   shared_examples_for "Validating emails" do
 
-    let(:timeouts) { 1 }
-
     before :each do
       I18n.locale = locale
-      allow(ValidEmail).to receive(:resolv_dns_timeouts).and_return timeouts
     end
 
     describe "validating email" do
@@ -177,14 +174,6 @@ describe EmailValidator do
         subject.email = 'john@nonexistentdomain.abc'
         expect(subject.valid?).to be_falsey
         expect(subject.errors[:email]).to eq errors
-      end
-
-      describe "Resolv::DNS.timeouts" do
-        it "sets the timeouts on the DNS" do
-          expect_any_instance_of(Resolv::DNS).to receive(:timeouts=).with(timeouts)
-          subject.email = 'john@gmail.com'
-          subject.valid?
-        end
       end
     end
 

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -117,4 +117,29 @@ describe ValidateEmail do
       expect(ValidateEmail.valid_local?('!#$%&\'*+-/=?^_`{|}~."\\\\\ \"(),:;<>@[]"')).to be_truthy
     end
   end
+
+  describe '.mx_valid?' do
+    let(:dns) { double(Resolv::DNS) }
+    let(:dns_resource) { double(Resolv::DNS::Resource::IN::MX) }
+
+    before do
+      expect(Resolv::DNS).to receive(:new).and_return(dns)
+      expect(dns).to receive(:close)
+    end
+
+    it "returns true when MX is true and it doesn't timeout" do
+      expect(dns).to receive(:getresources).and_return [dns_resource]
+      expect(ValidateEmail.mx_valid?('aloha@kmkonline.co.id')).to be_truthy
+    end
+
+    it "returns false when MX is false and it doesn't timeout" do
+      expect(dns).to receive(:getresources).and_return []
+      expect(ValidateEmail.mx_valid?('aloha@ga-ada-mx.com')).to be_falsey
+    end
+
+    it "returns config.default when times out", focus: true do
+      Timeout.should_receive(:timeout).and_raise(Timeout::Error)
+      expect(ValidateEmail.mx_valid?('aloha@ga-ada-mx.com')).to eq(ValidEmail.dns_timeout_return_value)
+    end
+  end
 end


### PR DESCRIPTION
Hello, we added a configurable timeout for the Resolv::DNS to make sure this code cannot lock-up our production workers if our DNS server is down or the domain cannot be resolved.  Seems like you were thinking about it: #4 
Cheers, IwanWan
