### PR TITLE
Fix domain validation behavior

### DIFF
--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -14,6 +14,9 @@ class EmailValidator < ActiveModel::EachValidator
     elsif r && options[:mx_with_fallback]
       require 'valid_email/mx_with_fallback_validator'
       r = MxWithFallbackValidator.new(:attributes => attributes, message: options[:message]).validate(record)
+    elsif r && options[:domain]
+      require 'valid_email/domain_validator'
+      r = DomainValidator.new(:attributes => attributes, message: options[:message]).validate(record)
     end
     # Check if domain is disposable
     if r && options[:ban_disposable_email]

--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -34,12 +34,10 @@ class ValidateEmail
 
       # Check if domain has DNS MX record
       if options[:mx]
-        require 'valid_email/mx_validator'
         return mx_valid?(value)
       end
 
       if options[:domain]
-        require 'valid_email/domain_validator'
         return domain_valid?(value)
       end
 
@@ -58,7 +56,7 @@ class ValidateEmail
       return false unless local.length <= LOCAL_MAX_LEN
       # Emails can be validated by segments delineated by '.', referred to as dot atoms.
       # See http://tools.ietf.org/html/rfc5322#section-3.2.3
-      return local.split('.', -1).all? { |da| valid_dot_atom?(da) }
+      local.split('.', -1).all? { |da| valid_dot_atom?(da) }
     end
 
     def valid_dot_atom?(dot_atom)
@@ -83,7 +81,7 @@ class ValidateEmail
         # If we're not in a quoted dot atom then no special characters are allowed.
         return false unless ((SPECIAL_CHARS | SPECIAL_ESCAPED_CHARS) & dot_atom.split('')).empty?
       end
-      return true
+      true
     end
 
     def mx_valid?(value, fallback=false)
@@ -110,6 +108,8 @@ class ValidateEmail
       return false unless m.domain
 
       !(m.domain =~ DOMAIN_REGEX).nil?
+    rescue Mail::Field::ParseError
+      false
     end
 
     def ban_disposable_email?(value)

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -52,6 +52,12 @@ describe EmailValidator do
   person_class_domain = Class.new do
     include ActiveModel::Validations
     attr_accessor :email
+    validates :email, :email => { :domain => true }
+  end
+
+  person_class_domain_separated = Class.new do
+    include ActiveModel::Validations
+    attr_accessor :email
     validates :email, :domain => true
   end
 
@@ -233,6 +239,30 @@ describe EmailValidator do
         subject.email = 'john@example.org'
         expect(subject.valid?).to be_truthy
         expect(subject.errors[:email]).to be_empty
+      end
+    end
+
+    describe "validating domain separately" do
+      subject { person_class_domain_separated.new }
+
+      it "does not pass with an invalid domain" do
+        subject.email = "test@example.org$\'"
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors[:email]).to eq errors
+      end
+
+      it "passes with valid domain" do
+        subject.email = 'john@example.org'
+        expect(subject.valid?).to be_truthy
+        expect(subject.errors[:email]).to be_empty
+      end
+
+      context 'with a mail that would raise a parsing error' do
+        it 'does not raise' do
+          subject.email = '@example.org'
+          expect(subject.valid?).to be_falsey
+          expect { subject.valid? }.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
It is stated in the Readme that a validation like `validates :email, email: { domain: true }` will work, which it doesn't.
This pull request fixes this behavior.
It also includes a fix that will catch parsing errors when using the DomainValidator separately.