### PR TITLE
Update valid_email.gemspec

### DIFF
--- a/valid_email.gemspec
+++ b/valid_email.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec", "~> 2.99"
   s.add_development_dependency "rake", '< 11.0'
-  s.add_runtime_dependency "mail", "~> 2.6.1"
+  s.add_runtime_dependency "mail", ">= 2.6.1"
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0')
     s.add_runtime_dependency 'mime-types', '<= 2.6.2'
   end


### PR DESCRIPTION
Change the dependency on `mail`.

Recently the `mail` gem was updated to support RFC5322. This is pretty important because it adds unicode support for email address (so addresses like `José <jose@example.com>` can be parsed). See: https://github.com/mikel/mail/issues/39

Let's bump the dependency on `mail` from `~> 2.6.1` to `>= 2.6.1` to support forward compatibility as the `mail` gem moves along. This will allow future updates without a dependency issue for folks using`valid_email`.