### PR TITLE
Allow non-ascii alphabetical characters in domain

### DIFF
--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -5,7 +5,7 @@ class ValidateEmail
     SPECIAL_CHARS = %w(( ) , : ; < > @ [ ])
     SPECIAL_ESCAPED_CHARS = %w(\  \\ ")
     LOCAL_MAX_LEN = 64
-    DOMAIN_REGEX = /\A^([[:alpha:]]{1}|([[:alnum:]][a-zA-Z0-9-]{0,61}[[:alnum:]]))(\.([[:alnum:]][a-zA-Z0-9-]{0,61}[[:alnum:]]))+\z/
+    DOMAIN_REGEX = /\A^([[:alpha:]]{1}|([[:alnum:]][[[:alnum:]]-]{0,61}[[:alnum:]]))(\.([[:alnum:]][a-zA-Z0-9-]{0,61}[[:alnum:]]))+\z/
 
     def valid?(value, user_options={})
       options = {

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -42,6 +42,8 @@ describe ValidateEmail do
           'a.aa',
           'test.xn--clchc0ea0b2g2a9gcd',
           'my-domain.com',
+          'тест.рф',
+          'umläüt-domain.de',
         ]
 
         valid_domains.each do |valid_domain|
@@ -59,7 +61,6 @@ describe ValidateEmail do
           'oeuoue.-oeuoue',
           'oueaaoeu.oeue-',
           'ouoeu.eou_ueoe',
-          'тест.рф',
           '.test.com',
           'test..com',
           'test@test.com',


### PR DESCRIPTION
Hello,

this pull requests allows umlauts domains. 
I have added a test case for German umlauts, and moved your Russian invalid example to a valid example (the Russian domain from the test is even registered).

While it is possible that some NICs might in the future block non-ASCII characters from their TLDs, currently everyone allows it.

If removing these characters was a design decision, please let me know.