### PR TITLE
 Fix bugs in DOMAIN_REGEX

### DIFF
--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -5,7 +5,7 @@ class ValidateEmail
     SPECIAL_CHARS = %w(( ) , : ; < > @ [ ])
     SPECIAL_ESCAPED_CHARS = %w(\  \\ ")
     LOCAL_MAX_LEN = 64
-    DOMAIN_REGEX = /\A(?:[[:alpha:]]|(?:[[:alnum:]][[[:alnum:]]-]{0,61}[[:alnum:]]))(?:\.(?:[[:alnum:]][a-zA-Z0-9-]{0,61}[[:alnum:]]))+\z/
+    DOMAIN_REGEX = /\A(?:[[:alnum:]](?:[[[:alnum:]]-]{0,61}[[:alnum:]])?)(?:\.(?:[[:alnum:]](?:[[[:alnum:]]-]{0,61}[[:alnum:]])?))+\z/
 
     def valid?(value, user_options={})
       options = {

--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -5,7 +5,7 @@ class ValidateEmail
     SPECIAL_CHARS = %w(( ) , : ; < > @ [ ])
     SPECIAL_ESCAPED_CHARS = %w(\  \\ ")
     LOCAL_MAX_LEN = 64
-    DOMAIN_REGEX = /\A^([[:alpha:]]{1}|([[:alnum:]][[[:alnum:]]-]{0,61}[[:alnum:]]))(\.([[:alnum:]][a-zA-Z0-9-]{0,61}[[:alnum:]]))+\z/
+    DOMAIN_REGEX = /\A(?:[[:alpha:]]|(?:[[:alnum:]][[[:alnum:]]-]{0,61}[[:alnum:]]))(?:\.(?:[[:alnum:]][a-zA-Z0-9-]{0,61}[[:alnum:]]))+\z/
 
     def valid?(value, user_options={})
       options = {

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -38,11 +38,14 @@ describe ValidateEmail do
           'mail-temporaire.fr',
           'mt2009.com',
           'mega.zik.dj',
+          '0.test.com',
           'e.test.com',
+          'mail.e.test.com',
           'a.aa',
           'test.xn--clchc0ea0b2g2a9gcd',
           'my-domain.com',
           'тест.рф',
+          'mail.тест.рф',
           'umläüt-domain.de',
         ]
 


### PR DESCRIPTION
`ValidateEmail#domain_valid?` (which is also called from `ValidateEmail#valid?` by default) fails to handle real email addresses like `@is.s.u-tokyo.ac.jp` (mine). Together with the bug, I've improved the regex in several ways.

- The regex contained duplicate start-of-string designators `/\A^/`. I've removed the latter.
- I've replaced `()` with non-capturing ones `(?:)`.
- Single-letter segments (labels) were erroneously rejected if placed after the first segment. Fixed.
- Single-digit segments were erroneously rejected. Note that the labels like `0clickemail` have already been accepted by the regex. Labels starting with digits were disallowed in RFC0952/RFC1035 but later allowed in RFC1123.
- Not all international domain names were allowed. I've fixed this to uniformly allow `[[:alnum:]]` in all places.