### PR TITLE
Use bundler 1.17.3 to pass CI in Ruby < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ rvm:
   - jruby-19mode
   - jruby-20mode
 before_install:
-  - gem install bundler
+  - gem install bundler:1.17.3


### PR DESCRIPTION
CI failing due to the release of bundler 2.0.