### PR TITLE
[spec] Mock MX resolution of example.org to nothing

### DIFF
--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -15,11 +15,19 @@ describe ValidateEmail do
     end
 
     context 'when mx: true option passed' do
+      def mock_dns_mx
+        dns = Resolv::DNS.new
+
+        allow(dns).to receive(:getresources).and_return([])
+        allow(Resolv::DNS).to receive(:new).and_return(dns)
+      end
+
       it 'returns true when mx record exist' do
         expect(ValidateEmail.valid?('user@gmail.com', mx: true)).to be_truthy
       end
 
       it "returns false when mx record doesn't exist" do
+        mock_dns_mx
         expect(ValidateEmail.valid?('user@example.com', mx: true)).to be_falsey
       end
     end


### PR DESCRIPTION
Mock MX DNS query to return nothing

Now it returns

; <<>> DiG 9.10.6 <<>> mx example.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 29253
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1220
;; QUESTION SECTION:
;example.com.			IN	MX

;; ANSWER SECTION:
example.com.		86085	IN	MX	0 .

;; Query time: 359 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Mon Apr 13 16:11:11 EAT 2020
;; MSG SIZE  rcvd: 55