### PR TITLE
IDNA-encode domain names with non-ASCII chars before MX lookup

### DIFF
--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -15,9 +15,9 @@ describe ValidateEmail do
     end
 
     context 'when mx: true option passed' do
-      def mock_dns_mx
-        dns = Resolv::DNS.new
+      let(:dns) { Resolv::DNS.new }
 
+      def mock_dns_mx
         allow(dns).to receive(:getresources).and_return([])
         allow(Resolv::DNS).to receive(:new).and_return(dns)
       end
@@ -29,6 +29,12 @@ describe ValidateEmail do
       it "returns false when mx record doesn't exist" do
         mock_dns_mx
         expect(ValidateEmail.valid?('user@example.com', mx: true)).to be_falsey
+      end
+
+      it "IDN-encodes the domain name if it contains multibyte characters" do
+        mock_dns_mx
+        ValidateEmail.valid?("user@\u{1F600}.com", mx: true)
+        expect(dns).to have_received(:getresources).with('xn--e28h.com', anything)
       end
     end
 

--- a/valid_email.gemspec
+++ b/valid_email.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 2.99"
   s.add_development_dependency "rake", '< 11.0'
   s.add_runtime_dependency "mail", ">= 2.6.1"
+  s.add_runtime_dependency "simpleidn"
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0')
     s.add_runtime_dependency 'mime-types', '<= 2.6.2'
   end


### PR DESCRIPTION
## TL;DR

Attempting to MX-validate email addresses with non-ASCII domain names results in encoding errors from `Resolv::DNS`. This PR IDNA-encodes such domains before trying to resolve them.

## Description

DNS supports only ASCII characters; however, many applications support non-ASCII characters in domain names, and use [IDNA](https://tools.ietf.org/html/rfc3490) to encode these as ASCII when making DNS requests. This includes mailservers, with IDNA now incorporated into [SMTP standards](https://tools.ietf.org/html/rfc6531), and IDN mailboxes increasingly being supported in popular MTAs.

`valid_email` uses the `mail` gem to extract the domain name from an email address, but because this gem isn't concerned with DNS, it doesn't need to handle IDNA-encoding. Meanwhile, the ruby stdlib `Resolv::DNS` [doesn't handle UTF8 domain names](https://bugs.ruby-lang.org/issues/4270), and seems unlikely to do so in the near future, if ever. This means that trying to validate non-ASCII domain names using `Resolv::DNS` frequently returns encoding errors.

This change therefore introduces a new dependency, [simpleidn](https://github.com/mmriis/simpleidn), and uses it to ASCII-encode any domains containing multibyte characters prior to checking their MX records.

## Rationale

I saw that this suggestion has been made before in #2, and decided against on the grounds of complexity. I'm very sympathetic to that, but I felt that since in the intervening years SMTP support for IDNA has been standardised and it's increasingly supported in real MTAs, it might be worth revisiting. Anecdotally, our site has seen a small but steadily-increasing number of users trying to register with non-ASCII email addresses, and we'd like to support them, since those addresses really are deliverable.

I think the `valid_email` gem feels like the right place to apply this logic because it's specifically involved with taking data from a context that supports UTF8 (the mail gem) and using it in a context that doesn't (DNS resolution).

Does this seem reasonable?