### PR TITLE
Test Ruby 3.0 support using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
-sudo: false
-language: ruby
+before_install:
+  - gem install bundler:1.17.3
 cache: bundler
+dist: xenial
+language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
+  - 2.0
   - 2.1
-  - 2.2.1
-  - 2.2.2
-  - 2.3.3
-  - 2.4.0
+  - 2.2
+  - 2.2
+  - 2.3
+  - 2.4
   - 2.5
   - 2.6
   - 2.7
-  - jruby-19mode
-  - jruby-20mode
-before_install:
-  - gem install bundler:1.17.3
+  - 3.0
+  - jruby-head


### PR DESCRIPTION
Ruby 3.0 was released on 25 Dec 2020. It's a good time to testing and using the gem on this platform as well.