### PR TITLE
Change !any? to none?

### DIFF
--- a/lib/valid_email/validate_email.rb
+++ b/lib/valid_email/validate_email.rb
@@ -28,7 +28,7 @@ class ValidateEmail
       return false unless m.domain.match(/^\S+$/)
 
       domain_dot_elements = m.domain.split(/\./)
-      return false unless domain_dot_elements.size > 1 && !domain_dot_elements.any?(&:empty?)
+      return false unless domain_dot_elements.size > 1 && domain_dot_elements.none?(&:empty?)
 
       # Ensure that the local segment adheres to adheres to RFC-5322
       return false unless valid_local?(m.local)


### PR DESCRIPTION
Negating the conditions reduces readability.
Therefore, instead of negating `any?` method called on a collection, is it better to call `none?` method on this collection.