### PR TITLE
Pass error message as a message option instead of the type

### DIFF
--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -22,7 +22,7 @@ class EmailValidator < ActiveModel::EachValidator
     end
     unless r
       msg = (options[:message] || I18n.t(:invalid, :scope => "valid_email.validations.email"))
-      record.errors.add attribute, (msg % {value: value})
+      record.errors.add attribute, message: (msg % {value: value})
     end
   end
 end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe EmailValidator do
   email_class = Class.new do
     include ActiveModel::Validations
+
     attr_accessor :email
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "TestModel")
+    end
   end
 
   person_class = Class.new(email_class) do


### PR DESCRIPTION
### Problem
Currently, the error message is passed as a type for an `ActiveModel::Error` instance.
```Ruby
record.errors.add attribute, (msg % {value: value})
```

The problem is that if there is any specific behavior based on the error type exists, it's barely possible to identify the error, especially with multiple locales used

```Ruby
if instance.errors.details[:email].include?(:invalid) 
  # do something
end

# but 
instance.errors.details #=> { :email=>[{ :error=><a particular locale message> }] }
```

For example,
```Ruby
class MyClass
  include ActiveModel::Validations

  attr_accessor :email

  validates :email, email: true
end

instance = MyClass.new
instance.valid?
```

Errors:
```Ruby
instance.errors #=> [#<ActiveModel::Error attribute=email, type=<a particular locale message>, options={}>]>
```

So if we need to know whether there is an invalid email error appeared we could stick to the type value but it is a string that is changed based on locale. All those brings extra complexity to identify the error.
Would be good to have the same error type no matter what the locale and message says
```Ruby
instance.errors.details #=> { :email=>[{ :error=>:invalid }] }
# instead of 
instance.errors.details #=> { :email=>[{ :error=><a particular locale message> }] }
```

### Purpose of the change
The purpose of the change is to pass the error message as an option
```Ruby
record.errors.add attribute, message: (msg % {value: value})  # default type is :invalid
```

And it will look the following way:
```Ruby
instance.errors #=> [#<ActiveModel::Error attribute=email, type=invalid, options={ message: <a particular locale message> }>]>
instance.errors.details #=> { :email=>[{ :error=>:invalid }] }
```
