### PR TITLE
Remove 'too many arguments for format string' warning

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ rvm:
   - 2.6
   - 2.7
   - 3.0
+  - 3.1
+  - 3.2
   - jruby-head
   - truffleruby-head

--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -22,7 +22,7 @@ class EmailValidator < ActiveModel::EachValidator
     end
     unless r
       msg = (options[:message] || I18n.t(:invalid, :scope => "valid_email.validations.email"))
-      record.errors.add attribute, message: (msg % {value: value})
+      record.errors.add attribute, message: I18n.interpolate(msgs, value: value)
     end
   end
 end


### PR DESCRIPTION

This gem is creating `email_validator.rb:25: warning: too many arguments for format string` warnings, which are harmless, but cost mental overhead every time I run the specs.

SInce I18n is already used and the format feels almost expected to go through it, I replaced the call with I18n.interpolate, which has existed with the same api since 2010.
Current specs suffice. 

I also add `--warning` to `.rspec`, to make the warnings visible during development. There are still some warnings printed from the email gem, but they are working on that (https://github.com/mikel/mail/pull/1551).

And I added ruby 3.1 and 3.2 to the travis matrix.

Please let me know what you think and if I should change anything.