### PR TITLE
fix: fixes typo in EmailValidator

### DIFF
--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -22,7 +22,7 @@ class EmailValidator < ActiveModel::EachValidator
     end
     unless r
       msg = (options[:message] || I18n.t(:invalid, :scope => "valid_email.validations.email"))
-      record.errors.add attribute, message: I18n.interpolate(msgs, value: value)
+      record.errors.add attribute, message: I18n.interpolate(msg, value: value)
     end
   end
 end


### PR DESCRIPTION
👋 

I was looking into some test failures after updating this gem to `0.1.4`. I'm encountering the issue in #120. 
While looking at the master branch (to see if the changes there fixed #120), I noticed there were a lot of tests that were failing due to a chance introduced in #122. 


It looks like the project doesn't have CI running, which could have detected this issue. 

